### PR TITLE
fix: Use `assert` instead of `let`

### DIFF
--- a/src/ids/cuid.gleam
+++ b/src/ids/cuid.gleam
@@ -148,7 +148,7 @@ external fn net_adm_localhost() -> List(Int) =
 
 fn get_fingerprint() -> String {
   let operator = base * base
-  let Ok(pid) =
+  assert Ok(pid) =
     os_getpid()
     |> char_list_to_string()
     |> int.parse()

--- a/test/ids/uuid_test.gleam
+++ b/test/ids/uuid_test.gleam
@@ -4,7 +4,7 @@ import gleam/bit_string
 import gleam/io
 
 pub fn gen_test() {
-  let Ok(id) = uuid.v4()
+  assert Ok(id) = uuid.v4()
 
   assert <<
     _:size(64),


### PR DESCRIPTION
In the newest version of Gleam, these lines of code no longer pass due
to not handling the `Error` case of `Result`. This patches fixes that
issue by using the `assert` keyword which skips this check.