### PR TITLE
Add module and function for generating NanoIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@
 
 - [cuid](https://github.com/ericelliott/cuid)
 - [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)
-
-## Coming Soon
-
 - [nanoid](https://github.com/ai/nanoid)
 
 ## Installation

--- a/src/ids/cuid.gleam
+++ b/src/ids/cuid.gleam
@@ -16,13 +16,11 @@
 //// let slug = cuid.slug(channel)
 //// ```
 
-import gleam/dynamic
 import gleam/int
 import gleam/list
 import gleam/erlang.{Millisecond}
 import gleam/otp/actor.{Continue, StartResult}
 import gleam/otp/process.{Sender}
-import gleam/otp/system
 import gleam/string
 
 /// The messages handled by the actor.

--- a/src/ids/nanoid.gleam
+++ b/src/ids/nanoid.gleam
@@ -1,0 +1,188 @@
+//// A module for generating NanoIDs, i.e., tiny, secure, URL-friendly, 
+//// and unique string IDs.
+////
+//// ### Usage
+//// ```gleam
+//// import ids/nanoid
+////
+//// let nanoid = nanoid.generate()
+//// ```
+
+import gleam/string
+import gleam/bit_string
+import gleam/float
+import gleam/int
+import gleam/list
+
+// Set the default alphabet to use when generating NanoIDs
+pub const default_alphabet: BitString = <<
+  "_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ":utf8,
+>>
+
+// Set the default size of the generated NanoIDs 
+pub const default_size: Int = 21
+
+external fn strong_rand_bytes(Int) -> BitString =
+  "crypto" "strong_rand_bytes"
+
+external fn shift_left(Int, Int) -> Int =
+  "erlang" "bsl"
+
+external fn and(Int, Int) -> Int =
+  "erlang" "band"
+
+external fn bin_to_list(BitString) -> List(Int) =
+  "binary" "bin_to_list"
+
+external fn log(Float) -> Float =
+  "math" "log"
+
+fn check_nanoid_args(size: Int, alphabet: BitString) -> Result(Bool, String) {
+  case check_size(size) {
+    Ok(True) ->
+      case check_alphabet(alphabet) {
+        Ok(True) ->
+          True
+          |> Ok
+        Error(error) ->
+          error
+          |> Error
+      }
+    Error(error) ->
+      error
+      |> Error
+  }
+}
+
+fn check_size(size: Int) -> Result(Bool, String) {
+  case size > 0 {
+    True ->
+      True
+      |> Ok
+    False -> {
+      let error: String =
+        "Error: The specified ID size is too small. Increase the size of the ID."
+      error
+      |> Error
+    }
+  }
+}
+
+fn check_alphabet(alphabet: BitString) -> Result(Bool, String) {
+  case bit_string.byte_size(alphabet) > 1 {
+    True ->
+      True
+      |> Ok
+    False -> {
+      let error: String =
+        "Error: The specified alphabet size is too small. Increase the size of the alphabet."
+      error
+      |> Error
+    }
+  }
+}
+
+// Internal function for generating a list of cryptographically
+// secure random bytes (represented by a list of ints)
+fn random_bytes(size: Int) -> List(Int) {
+  strong_rand_bytes(size)
+  |> bin_to_list()
+}
+
+// Calculate a bitmask value that can be used to transform byte vaules 
+// into values that are closer to the size of the alphabet used. The 
+// bitmask value will be the closest `2^31 - 1` number, that exceeds 
+// the alphabet size. For example, the bitmask of the alphabet of size 
+// 30 is 31 (00011111)
+fn calculate_mask(alphabet_length: Int) -> Int {
+  let v1 = log(int.to_float(alphabet_length - 1)) /. log(2.0)
+  let v2 = float.round(float.floor(v1))
+  shift_left(2, v2) - 1
+}
+
+// Calculate a step value that determines how many random bytes to 
+// generate. The number of random bytes is decided based on the ID 
+// 'size', 'bitmask' value, 'alphabet' size, and a number 1.6 
+// (using 1.6 gives the best performance according to benchmarks).
+fn calculate_step(mask: Int, size: Int, alphabet_length: Int) -> Int {
+  let step: Float =
+    float.ceiling(
+      1.6 *. int.to_float(mask) *. int.to_float(size) /. int.to_float(
+        alphabet_length,
+      ),
+    )
+  float.round(step)
+}
+
+pub fn generate() -> Result(BitString, String) {
+  // TODO: When optional arguments with defaults becomes a thing in Gleam
+  //       make it possble to pass an 'alphabet' and 'size'. For now just
+  //       use hardcoded defaults...
+  let alphabet: BitString = default_alphabet
+  assert Ok(alphabet_string) = bit_string.to_string(alphabet)
+  let alphabet_length: Int = string.length(alphabet_string)
+  let size: Int = default_size
+  case check_nanoid_args(size, alphabet) {
+    Ok(True) -> {
+      let mask = calculate_mask(alphabet_length)
+      let step = calculate_step(mask, size, alphabet_length)
+      do_generate(size, default_alphabet, mask, step, <<"":utf8>>)
+    }
+    Error(error) ->
+      error
+      |> Error
+  }
+}
+
+// Recursively generate a NanoID as long as the given size 
+// of the ID has not yet been reached
+fn do_generate(
+  size: Int,
+  alphabet: BitString,
+  mask: Int,
+  step: Int,
+  acc: BitString,
+) -> Result(BitString, String) {
+  case bit_string.byte_size(acc) >= size {
+    // Truncate the generated ID to the desired size
+    True -> {
+      assert Ok(nanoid) = bit_string.slice(acc, 0, size)
+      nanoid
+      |> Ok
+    }
+    // The NanoID is not yet the desired size, so continue 
+    // building up the ID
+    False ->
+      case generate_nanoid(step, alphabet, mask) {
+        Ok(partial_nanoid) ->
+          bit_string.concat([acc, partial_nanoid])
+          |> do_generate(size, alphabet, mask, step, _)
+        Error(error) ->
+          error
+          |> Error
+      }
+  }
+}
+
+fn generate_nanoid(
+  size: Int,
+  alphabet: BitString,
+  mask: Int,
+) -> Result(BitString, String) {
+  case check_nanoid_args(size, alphabet) {
+    Ok(True) ->
+      size
+      |> random_bytes()
+      |> list.map(fn(x: Int) -> BitString {
+        case bit_string.slice(alphabet, and(x, mask), 1) {
+          Ok(nanoid) -> nanoid
+          _ -> <<"":utf8>>
+        }
+      })
+      |> bit_string.concat()
+      |> Ok
+    Error(error) ->
+      error
+      |> Error
+  }
+}

--- a/test/ids/cuid_test.gleam
+++ b/test/ids/cuid_test.gleam
@@ -1,10 +1,7 @@
 import gleeunit/should
 import ids/cuid
-import gleam/int
 import gleam/iterator.{Done, Next}
-import gleam/list
 import gleam/map
-import gleam/order
 import gleam/pair
 import gleam/string
 

--- a/test/ids/nanoid_test.gleam
+++ b/test/ids/nanoid_test.gleam
@@ -1,0 +1,70 @@
+import gleeunit
+import ids/nanoid
+import gleeunit/should
+import gleam/list
+import gleam/string
+import gleam/bit_string
+import gleam/set.{Set}
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// Set the number of NanoIDs to generate and validate
+const n: Int = 25_000
+
+pub fn nanoid_test() {
+  let gen_nanoids =
+    list.repeat(<<"":utf8>>, n)
+    |> list.try_map(fn(_v: BitString) -> Result(BitString, String) {
+      nanoid.generate()
+    })
+
+  // Make sure the NanoIDs can be successfully generated
+  gen_nanoids
+  |> should.be_ok()
+
+  // Access list of successfully generated NanoIDs
+  assert Ok(nanoids) = gen_nanoids
+
+  // Make sure the generated IDs are non-empty bit strings
+  nanoids
+  |> list.all(fn(v: BitString) -> Bool {
+    case bit_string.byte_size(v) > 0 {
+      True -> True
+      False -> False
+    }
+  })
+  |> should.be_true()
+
+  // Make sure the generated IDs have the right size
+  nanoids
+  |> list.all(fn(v: BitString) -> Bool {
+    assert Ok(string) = bit_string.to_string(v)
+    let length: Int =
+      string
+      |> string.length()
+    case length == nanoid.default_size {
+      True -> True
+      False -> False
+    }
+  })
+  |> should.be_true()
+
+  // Make sure the generated IDs contain the right symbols
+  nanoids
+  |> list.all(fn(v: BitString) -> Bool {
+    assert Ok(nanoid_string) = bit_string.to_string(v)
+    assert Ok(alphabet) = bit_string.to_string(nanoid.default_alphabet)
+    nanoid_string
+    |> string.to_graphemes()
+    |> list.all(fn(w: String) -> Bool { string.contains(alphabet, w) })
+  })
+  |> should.be_true()
+
+  // Make sure the generated IDs are unique i.e., there are no collisions
+  nanoids
+  |> set.from_list()
+  |> fn(v: Set(BitString)) -> Bool { set.size(v) == list.length(nanoids) }
+  |> should.be_true()
+}

--- a/test/ids/nanoid_test.gleam
+++ b/test/ids/nanoid_test.gleam
@@ -11,7 +11,7 @@ pub fn main() {
 }
 
 // Set the number of NanoIDs to generate and validate
-const n: Int = 25_000
+const n: Int = 10_000
 
 pub fn nanoid_test() {
   let gen_nanoids =

--- a/test/ids/uuid_test.gleam
+++ b/test/ids/uuid_test.gleam
@@ -1,7 +1,6 @@
 import gleeunit/should
 import ids/uuid
 import gleam/bit_string
-import gleam/io
 
 pub fn gen_test() {
   assert Ok(id) = uuid.v4()


### PR DESCRIPTION
This PR adds a module (currently only) containing a single (public) function for generating cryptographically secure [NanoIDs](https://github.com/ai/nanoid#readme).

The Elixir and Erlang implementation was used as a guideline:
- https://github.com/railsmechanic/nanoid
- https://github.com/ukarim/enanoid

In the future a non-secure function could be added. 