### PR TITLE
Update generation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
 # ids
 
 ![CI](https://github.com/lrosa007/ids/workflows/test/badge.svg?branch=main)
+[![Package Version](https://img.shields.io/hexpm/v/ids)](https://hex.pm/packages/ids)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/ids/)
 
 ✨ Unique IDs for Gleam
 
-[read the docs](https://hexdocs.pm/ids/)
-
 ## Supported
 
-- [cuid](https://github.com/ericelliott/cuid)
+- [CUID](https://github.com/ericelliott/cuid)
 - [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)
-- [nanoid](https://github.com/ai/nanoid)
+- [NanoID](https://github.com/ai/nanoid)
 
 ## Installation
 
-If [available in Hex](https://www.rebar3.org/docs/dependencies#section-declaring-dependencies)
-this package can be installed by adding `ids` to your `gleam.toml` dependencies:
+The library is available on Hex so it can be added to your Gleam project by simply running:
 
 ```sh
 gleam add ids
@@ -23,6 +22,6 @@ gleam add ids
 
 ## References
 
-1. [original cuid](https://en.wikipedia.org/wiki/Universally_unique_identifier)
-2. [elixir cuid](https://github.com/duailibe/cuid)
+1. [Original CUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)
+2. [Elixir CUID](https://github.com/duailibe/cuid)
 3. [Ecto UUID](https://github.com/elixir-ecto/ecto/blob/v3.5.4/lib/ecto/uuid.ex)

--- a/gleam.toml
+++ b/gleam.toml
@@ -4,5 +4,5 @@ licences = ["Apache-2.0"]
 description = "✨ Unique IDs for Gleam"
 repository = { type = "github", user = "rvcas", repo = "ids" }
 
-dependencies = { gleam_stdlib = "~> 0.20", gleam_otp = "~> 0.3", gleam_erlang = "~> 0.9" }
+dependencies = { gleam_stdlib = "~> 0.21", gleam_otp = "~> 0.4", gleam_erlang = "~> 0.9" }
 dev-dependencies = { gleeunit = "~> 0.6" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.9.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "15D0B66DA08D63C16EDDF32A70F6EB49E44DC83DB0370B7A45F1E954F8A23174" },
-  { name = "gleam_otp", version = "0.3.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "9F779074D0CD3760E280E24247BA17FC673D654234D56B3A8F187DC8FDE299B7" },
-  { name = "gleam_stdlib", version = "0.20.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "E5715F0CDCB3AB1BB73C6C35E46DA223997F680550E17CE46BC88B710E061CCE" },
+  { name = "gleam_erlang", version = "0.9.3", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0430CFF5DAFAB54C97D6F19AA98BDDAD5E7AA245AC240547F4C0DBC26CDAE85E" },
+  { name = "gleam_otp", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "3F05090CEDFBA5B6DE2AEE20868F92E815D287E71807DAD5663DAA1B566953C2" },
+  { name = "gleam_stdlib", version = "0.22.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "9C6C66EDAAFD097267089565488DEDFC111A0497DE9CB2C42248E26330CC48E9" },
   { name = "gleeunit", version = "0.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "5BF486C3E135B7F5ED8C054925FC48E5B2C79016A39F416FD8CF2E860520EE55" },
 ]
 
 [requirements]
 gleam_erlang = "~> 0.9"
-gleam_otp = "~> 0.3"
-gleam_stdlib = "~> 0.20"
+gleam_otp = "~> 0.4"
+gleam_stdlib = "~> 0.21"
 gleeunit = "~> 0.6"

--- a/src/ids/uuid.gleam
+++ b/src/ids/uuid.gleam
@@ -1,4 +1,4 @@
-//// A module for generating a UUID (Universally Unique Identifier).
+//// A module for generating UUIDs (Universally Unique Identifiers).
 ////
 //// The module currently supports UUID versions:
 //// - Version 4 (random)

--- a/src/ids/uuid.gleam
+++ b/src/ids/uuid.gleam
@@ -1,19 +1,23 @@
-//// Generating (random) UUIDs
+//// A module for generating a UUID (Universally Unique Identifier).
 ////
-//// Supports multiple versions.
+//// The module currently supports UUID versions:
+//// - Version 4 (random)
 ////
-//// ### Usage
-//// ```gleam
-//// import ids/uuid
-////
-////
-//// let id = cuid.v4()
-//// ```
 
 import gleam/bit_string
 
-/// Generates a version 4 (random) UUID.
-pub fn v4() -> Result(String, Nil) {
+/// Generates a version 4 (random) UUID. The version 4 UUID produced
+/// by this function is generated using a cryptographically secure 
+/// random number generator.
+///
+/// ### Usage
+/// ```gleam
+/// import ids/uuid
+///
+/// assert Ok(id) = uuid.generate_v4()
+/// ```
+///
+pub fn generate_v4() -> Result(String, String) {
   let <<u0:size(48), _:size(4), u1:size(12), _:size(2), u2:size(62)>> =
     crypto_strong_rand_bytes(16)
 
@@ -52,7 +56,7 @@ pub fn v4() -> Result(String, Nil) {
     e12:size(4),
   >> = <<u0:size(48), 4:size(4), u1:size(12), 2:size(2), u2:size(62)>>
 
-  let id = <<
+  let bitstr_id = <<
     e(a1),
     e(a2),
     e(a3),
@@ -91,7 +95,16 @@ pub fn v4() -> Result(String, Nil) {
     e(e12),
   >>
 
-  bit_string.to_string(id)
+  case bit_string.to_string(bitstr_id) {
+    Ok(str_id) ->
+      str_id
+      |> Ok
+    Error(_) -> {
+      let error: String = "Error: BitString could not be converted to String."
+      error
+      |> Error
+    }
+  }
 }
 
 fn e(n: Int) -> Int {

--- a/test/ids/cuid_test.gleam
+++ b/test/ids/cuid_test.gleam
@@ -5,14 +5,14 @@ import gleam/map
 import gleam/pair
 import gleam/string
 
-pub fn gen_test() {
+pub fn generate_test() {
   assert Ok(channel) = cuid.start()
 
-  fn() { cuid.gen(channel) }
+  fn() { cuid.generate(channel) }
   |> check_collision()
   |> should.be_true()
 
-  cuid.gen(channel)
+  cuid.generate(channel)
   |> string.starts_with("c")
   |> should.be_true()
 }

--- a/test/ids/cuid_test.gleam
+++ b/test/ids/cuid_test.gleam
@@ -5,7 +5,7 @@ import gleam/map
 import gleam/pair
 import gleam/string
 
-pub fn generate_test() {
+pub fn gen_test() {
   assert Ok(channel) = cuid.start()
 
   fn() { cuid.generate(channel) }

--- a/test/ids/nanoid_test.gleam
+++ b/test/ids/nanoid_test.gleam
@@ -14,9 +14,9 @@ pub fn main() {
 const n: Int = 10_000
 
 pub fn nanoid_test() {
-  let gen_nanoids =
-    list.repeat(<<"":utf8>>, n)
-    |> list.try_map(fn(_v: BitString) -> Result(BitString, String) {
+  let gen_nanoids: Result(List(String), String) =
+    list.repeat("", n)
+    |> list.try_map(fn(_v: String) -> Result(String, String) {
       nanoid.generate()
     })
 
@@ -29,8 +29,9 @@ pub fn nanoid_test() {
 
   // Make sure the generated IDs are non-empty bit strings
   nanoids
-  |> list.all(fn(v: BitString) -> Bool {
-    case bit_string.byte_size(v) > 0 {
+  |> list.all(fn(v: String) -> Bool {
+    let bitstr_v: BitString = bit_string.from_string(v)
+    case bit_string.byte_size(bitstr_v) > 0 {
       True -> True
       False -> False
     }
@@ -39,8 +40,9 @@ pub fn nanoid_test() {
 
   // Make sure the generated IDs have the right size
   nanoids
-  |> list.all(fn(v: BitString) -> Bool {
-    assert Ok(string) = bit_string.to_string(v)
+  |> list.all(fn(v: String) -> Bool {
+    let bitstr_v: BitString = bit_string.from_string(v)
+    assert Ok(string) = bit_string.to_string(bitstr_v)
     let length: Int =
       string
       |> string.length()
@@ -53,10 +55,9 @@ pub fn nanoid_test() {
 
   // Make sure the generated IDs contain the right symbols
   nanoids
-  |> list.all(fn(v: BitString) -> Bool {
-    assert Ok(nanoid_string) = bit_string.to_string(v)
+  |> list.all(fn(v: String) -> Bool {
     assert Ok(alphabet) = bit_string.to_string(nanoid.default_alphabet)
-    nanoid_string
+    v
     |> string.to_graphemes()
     |> list.all(fn(w: String) -> Bool { string.contains(alphabet, w) })
   })
@@ -65,6 +66,6 @@ pub fn nanoid_test() {
   // Make sure the generated IDs are unique i.e., there are no collisions
   nanoids
   |> set.from_list()
-  |> fn(v: Set(BitString)) -> Bool { set.size(v) == list.length(nanoids) }
+  |> fn(v: Set(String)) -> Bool { set.size(v) == list.length(nanoids) }
   |> should.be_true()
 }

--- a/test/ids/uuid_test.gleam
+++ b/test/ids/uuid_test.gleam
@@ -3,7 +3,7 @@ import ids/uuid
 import gleam/bit_string
 
 pub fn gen_test() {
-  assert Ok(id) = uuid.v4()
+  assert Ok(id) = uuid.generate_v4()
 
   assert <<
     _:size(64),


### PR DESCRIPTION
This PR tries to unify the ID generation methods (based on https://github.com/rvcas/ids/issues/3) such that:

- All functions return either a `String` or a `Result(String, String)`
- All ID generation functions in the modules are given the name `generate`. Modules containing multiple ID generation functions get an additional name appended to `generate`.  E.g., the different UUID generation functions in the `uuid` module would be called `uuid.generate_v1`, `uuid.generate_v2`, etc.

The PR also updates the `README.md` and dependencies.