### PR TITLE
Update for latest Gleam OTP

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.19.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "720D1E0A0CEBBD51C4AA88501D1D4FBFEF4AA7B3332C994691ED944767A52582" },
-  { name = "gleam_otp", version = "0.5.3", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "6E705B69464237353E0380AC8143BDB29A3F0BF6168755D5F2D6E55A34A8B077" },
-  { name = "gleam_stdlib", version = "0.29.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B296BF9B8AA384A6B64CD49F333016A9DCA6AC73A95400D17F2271E072EFF986" },
-  { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
+  { name = "gleam_erlang", version = "0.22.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "367D8B41A7A86809928ED1E7E55BFD0D46D7C4CF473440190F324AFA347109B4" },
+  { name = "gleam_otp", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "ED7381E90636E18F5697FD7956EECCA635A3B65538DC2BE2D91A38E61DCE8903" },
+  { name = "gleam_stdlib", version = "0.30.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "8D8BF3790AA31176B1E1C0B517DD74C86DA8235CF3389EA02043EE4FD82AE3DC" },
+  { name = "gleeunit", version = "0.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "1397E5C4AC4108769EE979939AC39BF7870659C5AFB714630DEEEE16B8272AD5" },
 ]
 
 [requirements]

--- a/src/ids/cuid.gleam
+++ b/src/ids/cuid.gleam
@@ -9,7 +9,7 @@
 import gleam/int
 import gleam/list
 import gleam/erlang.{Millisecond}
-import gleam/otp/actor.{Continue, Next, StartResult}
+import gleam/otp/actor.{Next, StartResult}
 import gleam/erlang/process.{Subject}
 import gleam/string
 
@@ -69,7 +69,7 @@ pub fn is_slug(slug: String) -> Bool {
 
 const base: Int = 36
 
-fn handle_msg(msg: Message, state: State) -> Next(State) {
+fn handle_msg(msg: Message, state: State) -> Next(Message, State) {
   case msg {
     Generate(reply) -> {
       let id =
@@ -82,7 +82,7 @@ fn handle_msg(msg: Message, state: State) -> Next(State) {
           random_block(),
         ])
       actor.send(reply, id)
-      Continue(State(..state, count: new_count(state.count)))
+      actor.continue(State(..state, count: new_count(state.count)))
     }
     GenerateSlug(reply) -> {
       let slug =
@@ -99,7 +99,7 @@ fn handle_msg(msg: Message, state: State) -> Next(State) {
           |> string.slice(-2, 2),
         ])
       actor.send(reply, slug)
-      Continue(State(..state, count: new_count(state.count)))
+      actor.continue(State(..state, count: new_count(state.count)))
     }
   }
 }


### PR DESCRIPTION
The previous version of this library doesn't compile with the latest Gleam OTP due to a breaking change, sorry about that.

This fixes it, thank you!