### PR TITLE
Add Snowflake IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,4 @@ gleam add ids
 1. [Original CUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)
 2. [Elixir CUID](https://github.com/duailibe/cuid)
 3. [Ecto UUID](https://github.com/elixir-ecto/ecto/blob/v3.5.4/lib/ecto/uuid.ex)
-4. [Elixir Snowflake ID](https://github.com/thomas9911/snowflake_id)
-5. [Rust Snowflake ID](https://github.com/BinChengZhao/snowflake-rs)
+4. [Rust Snowflake ID](https://github.com/BinChengZhao/snowflake-rs)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [CUID](https://github.com/ericelliott/cuid)
 - [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)
 - [NanoID](https://github.com/ai/nanoid)
+- [Snowflake ID](https://en.wikipedia.org/wiki/Snowflake_ID)
 
 ## Installation
 
@@ -25,3 +26,4 @@ gleam add ids
 1. [Original CUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)
 2. [Elixir CUID](https://github.com/duailibe/cuid)
 3. [Ecto UUID](https://github.com/elixir-ecto/ecto/blob/v3.5.4/lib/ecto/uuid.ex)
+4. [Elixir Snowflake ID](https://github.com/thomas9911/snowflake_id)

--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ gleam add ids
 2. [Elixir CUID](https://github.com/duailibe/cuid)
 3. [Ecto UUID](https://github.com/elixir-ecto/ecto/blob/v3.5.4/lib/ecto/uuid.ex)
 4. [Elixir Snowflake ID](https://github.com/thomas9911/snowflake_id)
+5. [Rust Snowflake ID](https://github.com/BinChengZhao/snowflake-rs)

--- a/gleam.toml
+++ b/gleam.toml
@@ -5,9 +5,9 @@ description = "✨ Unique IDs for Gleam"
 repository = { type = "github", user = "rvcas", repo = "ids" }
 
 [dependencies]
-gleam_stdlib = "~> 0.29"
-gleam_otp = "~> 0.5"
-gleam_erlang = "~> 0.18"
+gleam_stdlib = "~> 0.31"
+gleam_otp = "~> 0.7"
+gleam_erlang = "~> 0.22"
 
 [dev-dependencies]
 gleeunit = "~> 0.10"

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,12 +4,12 @@
 packages = [
   { name = "gleam_erlang", version = "0.22.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "367D8B41A7A86809928ED1E7E55BFD0D46D7C4CF473440190F324AFA347109B4" },
   { name = "gleam_otp", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "ED7381E90636E18F5697FD7956EECCA635A3B65538DC2BE2D91A38E61DCE8903" },
-  { name = "gleam_stdlib", version = "0.30.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "8D8BF3790AA31176B1E1C0B517DD74C86DA8235CF3389EA02043EE4FD82AE3DC" },
+  { name = "gleam_stdlib", version = "0.31.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "6D1BC5B4D4179B9FEE866B1E69FE180AC2CE485AD90047C0B32B2CA984052736" },
   { name = "gleeunit", version = "0.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "1397E5C4AC4108769EE979939AC39BF7870659C5AFB714630DEEEE16B8272AD5" },
 ]
 
 [requirements]
-gleam_erlang = { version = "~> 0.18" }
-gleam_otp = { version = "~> 0.5" }
-gleam_stdlib = { version = "~> 0.29" }
+gleam_erlang = { version = "~> 0.22" }
+gleam_otp = { version = "~> 0.7" }
+gleam_stdlib = { version = "~> 0.31" }
 gleeunit = { version = "~> 0.10" }

--- a/src/ids/snowflake.gleam
+++ b/src/ids/snowflake.gleam
@@ -1,0 +1,121 @@
+//// A module for generating Snowflake IDs.
+
+import gleam/int
+import gleam/string
+import gleam/result
+import gleam/erlang
+import gleam/otp/actor.{Next}
+import gleam/erlang/process.{Subject}
+
+@external(erlang, "binary", "encode_unsigned")
+fn encode_unsigned(i: Int) -> BitString
+
+/// The messages handled by the actor.
+/// The actor shouldn't be called directly so this type is opaque.
+pub opaque type Message {
+  Generate(reply_with: Subject(Int))
+}
+
+/// The internal state of the actor.
+/// The state keeps track of the Snowflake parts.
+pub opaque type State {
+  State(epoch: Int, last_time: Int, machine_id: Int, node_id: Int, idx: Int)
+}
+
+/// Starts a Snowflake generator.
+pub fn start(machine_id: Int, node_id: Int) -> Result(Subject(Message), String) {
+  start_with_epoch(machine_id, node_id, 0)
+}
+
+/// Starts a Snowflake generator with an epoch offset.
+pub fn start_with_epoch(
+  machine_id: Int,
+  node_id: Int,
+  epoch: Int,
+) -> Result(Subject(Message), String) {
+  case epoch > erlang.system_time(erlang.Millisecond) {
+    True -> Error("Error: Epoch can't be larger than current time.")
+    False ->
+      State(
+        epoch: epoch,
+        last_time: 0,
+        machine_id: machine_id,
+        node_id: node_id,
+        idx: 0,
+      )
+      |> actor.start(handle_msg)
+      |> result.map_error(fn(err) {
+        "Error: Couldn't start actor. Reason: " <> string.inspect(err)
+      })
+  }
+}
+
+/// Generates a Snowflake ID using the given channel.
+///
+/// ### Usage
+/// ```gleam
+/// import ids/snowflake
+///
+/// let assert Ok(channel) = snowflake.start(machine_id: 1, node_id: 2)
+/// let id: Int = snowflake.generate(channel)
+/// 
+/// let discord_epoch = 1_420_070_400_000 
+/// let assert Ok(d_channel) = snowflake.start_with_epoch(machine_id: 1, node_id: 2, epoch: discord_epoch)
+/// let discord_id: Int = snowflake.generate(d_channel)
+/// ```
+pub fn generate(channel: Subject(Message)) -> Int {
+  actor.call(channel, Generate, 1000)
+}
+
+/// Decodes a Snowflake ID into #(timestamp, machine_id, node_id, idx).
+pub fn decode(snowflake: Int) -> Result(#(Int, Int, Int, Int), String) {
+  case encode_unsigned(snowflake) {
+    <<
+      timestamp:int-size(42),
+      machine_id:int-size(5),
+      node_id:int-size(5),
+      idx:int-size(12),
+    >> -> Ok(#(timestamp, machine_id, node_id, idx))
+    _other -> Error("Error: Couldn't decode snowflake id.")
+  }
+}
+
+/// Actor message handler.
+fn handle_msg(msg: Message, state: State) -> Next(Message, State) {
+  case msg {
+    Generate(reply) -> {
+      let new_state = update_state(state)
+
+      let snowflake =
+        new_state.last_time
+        |> int.bitwise_shift_left(22)
+        |> int.bitwise_or({
+          new_state.machine_id
+          |> int.bitwise_shift_left(17)
+          |> int.bitwise_or({
+            new_state.node_id
+            |> int.bitwise_shift_left(12)
+            |> int.bitwise_or(new_state.idx)
+          })
+        })
+
+      actor.send(reply, snowflake)
+      actor.continue(new_state)
+    }
+  }
+}
+
+/// Prepares the state for generation.
+/// Handles incrementing if id is being generated in the same millisecond.
+/// Calls itself recursively to make a millisecond pass if all 4096 ids have been generated in the past millisecond.
+fn update_state(state: State) -> State {
+  let now =
+    erlang.system_time(erlang.Millisecond)
+    |> int.subtract(state.epoch)
+
+  case state.last_time {
+    lt if lt == now && state.idx < 4095 -> State(..state, idx: state.idx + 1)
+    lt if lt == now -> update_state(state)
+    _other -> State(..state, last_time: now)
+  }
+}

--- a/test/ids/snowflake_test.gleam
+++ b/test/ids/snowflake_test.gleam
@@ -1,212 +1,63 @@
-//// A module for generating Snowflake IDs.
-
+import ids/snowflake
+import gleeunit/should
 import gleam/string
 import gleam/int
-import gleam/result
 import gleam/list
 import gleam/erlang
-import gleam/otp/actor.{Next, StartResult}
-import gleam/erlang/process.{Subject}
 
-pub const crockford_alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+pub fn gen_test() {
+  let machine_id = 1
+  let node_id = 1
+  let assert Ok(channel) = snowflake.start(machine_id, node_id)
 
-pub const max_time = 281_474_976_710_655
+  let snowflake = snowflake.generate(channel)
 
-@external(erlang, "crypto", "strong_rand_bytes")
-fn crypto_strong_rand_bytes(n: Int) -> BitString
+  snowflake
+  |> int.to_string()
+  |> string.length()
+  |> should.equal(19)
 
-@external(erlang, "erlang", "bit_size")
-fn bit_size(b: BitString) -> Int
+  let assert Ok(#(timestamp, m_id, n_id, idx)) = snowflake.decode(snowflake)
 
-@external(erlang, "binary", "decode_unsigned")
-fn decode_unsigned(b: BitString) -> Int
+  { timestamp <= erlang.system_time(erlang.Millisecond) }
+  |> should.be_true()
+  m_id
+  |> should.equal(machine_id)
+  n_id
+  |> should.equal(node_id)
+  idx
+  |> should.equal(0)
 
-@external(erlang, "binary", "encode_unsigned")
-fn encode_unsigned(i: Int) -> BitString
-
-/// The messages handled by the actor.
-/// The actor shouldn't be called directly so this type is opaque.
-pub opaque type Message {
-  Generate(reply_with: Subject(Result(String, String)))
+  list.range(1, 5000)
+  |> list.map(fn(_) { snowflake.generate(channel) })
+  |> list.unique()
+  |> list.length()
+  |> should.equal(5000)
 }
 
-/// The internal state of the actor.
-/// The state keeps track of the Snowflake parts.
-pub opaque type State {
-  State(epoch: Int, last_time: Int, machine_id: Int, node_id: Int, idx: Int)
-}
+pub fn gen_with_epoch_test() -> Nil {
+  let machine_id = 1
+  let node_id = 1
+  let now = erlang.system_time(erlang.Millisecond)
 
-/// Starts a Snowflake generator.
-pub fn start(machine_id: Int, node_id: Int) -> StartResult(Message) {
-  start_with_epoch(machine_id, node_id, 0)
-}
+  let now_much = erlang.system_time(erlang.Millisecond) + 1000
+  snowflake.start_with_epoch(machine_id, node_id, now_much)
+  |> should.be_error()
 
-/// Starts a Snowflake generator with an epoch offset.
-pub fn start_with_epoch(
-  machine_id: Int,
-  node_id: Int,
-  epoch: Int,
-) -> StartResult(Message) {
-  State(
-    epoch: epoch,
-    last_time: 0,
-    machine_id: machine_id,
-    node_id: node_id,
-    idx: 0,
-  )
-  |> actor.start(handle_msg)
-}
+  let discord_epoch = 1_420_070_400_000
+  let assert Ok(channel) =
+    snowflake.start_with_epoch(machine_id, node_id, discord_epoch)
 
-/// Generates an ULID using the given channel with a monotonicity check.
-/// This guarantees sortability if multiple ULID get created in the same millisecond.
-///
-/// ### Usage
-/// ```gleam
-/// import ids/ulid
-///
-/// let assert Ok(channel) = ulid.start()
-/// let Ok(id) = ulid.monotonic_generate(channel)
-/// ```
-pub fn generate(channel: Subject(Message)) -> Result(String, String) {
-  actor.call(channel, Generate, 1000)
-}
+  let discord_snowflake = snowflake.generate(channel)
 
-/// Generates an ULID with the supplied timestamp and randomness.
-pub fn from_parts(
-  timestamp: Int,
-  randomness: BitString,
-) -> Result(String, String) {
-  case #(timestamp, randomness) {
-    #(time, <<rand:bit_string-size(80)>>) if time <= max_time ->
-      <<timestamp:size(48), rand:bit_string>>
-      |> encode_base32()
-      |> Ok
-    _other -> {
-      let error =
-        string.concat([
-          "Error: The timestamp is too large or randomness isn't 80 bits. Please use an Unix timestamp smaller than ",
-          int.to_string(max_time),
-          ".",
-        ])
-      Error(error)
-    }
-  }
-}
+  discord_snowflake
+  |> int.to_string()
+  |> string.length()
+  |> should.equal(19)
 
-/// Decodes an ULID into #(timestamp, randomness).
-pub fn decode(ulid: String) -> Result(#(Int, BitString), String) {
-  case decode_base32(ulid) {
-    Ok(<<timestamp:unsigned-size(48), randomness:bit_string-size(80)>>) ->
-      Ok(#(timestamp, randomness))
-    _other -> Error("Error: Decoding failed. Is a valid ULID being supplied?")
-  }
-}
+  let assert Ok(#(timestamp, _, _, _)) = snowflake.decode(discord_snowflake)
 
-/// Actor message handler.
-fn handle_msg(msg: Message, state: State) -> Next(Message, State) {
-  case msg {
-    Generate(reply) -> {
-      erlang.system_time(erlang.Millisecond)
-      |> generate_response_ulid(reply, state)
-    }
-  }
-}
-
-/// Response message helper.
-fn generate_response_ulid(
-  timestamp: Int,
-  reply: Subject(Result(String, String)),
-  state: State,
-) -> Next(Message, State) {
-  case state.last_time == timestamp {
-    True -> {
-      let randomness =
-        state.last_random
-        |> decode_unsigned()
-        |> int.add(1)
-        |> encode_unsigned()
-
-      case from_parts(timestamp, randomness) {
-        Ok(ulid) -> actor.send(reply, Ok(ulid))
-        _error -> actor.send(reply, Error("Error: Couldn't generate ULID."))
-      }
-
-      actor.continue(State(last_time: timestamp, last_random: randomness))
-    }
-
-    False -> {
-      let randomness = crypto_strong_rand_bytes(10)
-
-      case from_parts(timestamp, randomness) {
-        Ok(ulid) -> actor.send(reply, Ok(ulid))
-        _error -> actor.send(reply, Error("Error: Couldn't generate ULID."))
-      }
-
-      actor.continue(State(last_time: timestamp, last_random: randomness))
-    }
-  }
-}
-
-/// Encode a bit_string using crockfords base32 encoding.
-fn encode_base32(bytes: BitString) -> String {
-  // calculate how many bits to pad to make the bit_string divisible by 5
-  let to_pad =
-    bytes
-    |> bit_size()
-    |> int.modulo(5)
-    |> result.unwrap(5)
-    |> int.subtract(5)
-    |> int.absolute_value()
-    |> int.modulo(5)
-    |> result.unwrap(0)
-
-  encode_bytes(<<0:size(to_pad), bytes:bit_string>>)
-}
-
-/// Recursively grabs 5 bits and uses them as index in the crockford alphabet and concatinates them to a string.
-fn encode_bytes(binary: BitString) -> String {
-  case binary {
-    <<index:unsigned-size(5), rest:bit_string>> -> {
-      crockford_alphabet
-      |> string.to_graphemes()
-      |> list.at(index)
-      |> result.unwrap("0")
-      |> string.append(encode_bytes(rest))
-    }
-    <<>> -> ""
-  }
-}
-
-/// Decode a string using crockford's base32 encoding.
-fn decode_base32(binary: String) -> Result(BitString, Nil) {
-  let crockford_with_index =
-    crockford_alphabet
-    |> string.to_graphemes()
-    |> list.index_map(fn(i, x) { #(x, i) })
-
-  let bits =
-    binary
-    |> string.to_graphemes()
-    |> list.fold(
-      <<>>,
-      fn(acc, c) {
-        let index =
-          crockford_with_index
-          |> list.key_find(c)
-          |> result.unwrap(0)
-
-        <<acc:bit_string, index:5>>
-      },
-    )
-
-  let padding =
-    bits
-    |> bit_size()
-    |> int.modulo(8)
-    |> result.unwrap(0)
-
-  case bits {
-    <<0:size(padding), res:bit_string>> -> Ok(res)
-    _other -> Error(Nil)
-  }
+  let t = timestamp + discord_epoch
+  { t >= now && t <= { now + 1000 } }
+  |> should.be_true()
 }

--- a/test/ids/snowflake_test.gleam
+++ b/test/ids/snowflake_test.gleam
@@ -7,8 +7,7 @@ import gleam/erlang
 
 pub fn gen_test() {
   let machine_id = 1
-  let node_id = 1
-  let assert Ok(channel) = snowflake.start(machine_id, node_id)
+  let assert Ok(channel) = snowflake.start(machine_id)
 
   let snowflake = snowflake.generate(channel)
 
@@ -17,14 +16,12 @@ pub fn gen_test() {
   |> string.length()
   |> should.equal(19)
 
-  let assert Ok(#(timestamp, m_id, n_id, idx)) = snowflake.decode(snowflake)
+  let assert Ok(#(timestamp, m_id, idx)) = snowflake.decode(snowflake)
 
   { timestamp <= erlang.system_time(erlang.Millisecond) }
   |> should.be_true()
   m_id
   |> should.equal(machine_id)
-  n_id
-  |> should.equal(node_id)
   idx
   |> should.equal(0)
 
@@ -37,16 +34,14 @@ pub fn gen_test() {
 
 pub fn gen_with_epoch_test() -> Nil {
   let machine_id = 1
-  let node_id = 1
   let now = erlang.system_time(erlang.Millisecond)
 
   let now_much = erlang.system_time(erlang.Millisecond) + 1000
-  snowflake.start_with_epoch(machine_id, node_id, now_much)
+  snowflake.start_with_epoch(machine_id, now_much)
   |> should.be_error()
 
   let discord_epoch = 1_420_070_400_000
-  let assert Ok(channel) =
-    snowflake.start_with_epoch(machine_id, node_id, discord_epoch)
+  let assert Ok(channel) = snowflake.start_with_epoch(machine_id, discord_epoch)
 
   let discord_snowflake = snowflake.generate(channel)
 
@@ -55,7 +50,7 @@ pub fn gen_with_epoch_test() -> Nil {
   |> string.length()
   |> should.equal(19)
 
-  let assert Ok(#(timestamp, _, _, _)) = snowflake.decode(discord_snowflake)
+  let assert Ok(#(timestamp, _, _)) = snowflake.decode(discord_snowflake)
 
   let t = timestamp + discord_epoch
   { t >= now && t <= { now + 1000 } }

--- a/test/ids/snowflake_test.gleam
+++ b/test/ids/snowflake_test.gleam
@@ -1,0 +1,212 @@
+//// A module for generating Snowflake IDs.
+
+import gleam/string
+import gleam/int
+import gleam/result
+import gleam/list
+import gleam/erlang
+import gleam/otp/actor.{Next, StartResult}
+import gleam/erlang/process.{Subject}
+
+pub const crockford_alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+pub const max_time = 281_474_976_710_655
+
+@external(erlang, "crypto", "strong_rand_bytes")
+fn crypto_strong_rand_bytes(n: Int) -> BitString
+
+@external(erlang, "erlang", "bit_size")
+fn bit_size(b: BitString) -> Int
+
+@external(erlang, "binary", "decode_unsigned")
+fn decode_unsigned(b: BitString) -> Int
+
+@external(erlang, "binary", "encode_unsigned")
+fn encode_unsigned(i: Int) -> BitString
+
+/// The messages handled by the actor.
+/// The actor shouldn't be called directly so this type is opaque.
+pub opaque type Message {
+  Generate(reply_with: Subject(Result(String, String)))
+}
+
+/// The internal state of the actor.
+/// The state keeps track of the Snowflake parts.
+pub opaque type State {
+  State(epoch: Int, last_time: Int, machine_id: Int, node_id: Int, idx: Int)
+}
+
+/// Starts a Snowflake generator.
+pub fn start(machine_id: Int, node_id: Int) -> StartResult(Message) {
+  start_with_epoch(machine_id, node_id, 0)
+}
+
+/// Starts a Snowflake generator with an epoch offset.
+pub fn start_with_epoch(
+  machine_id: Int,
+  node_id: Int,
+  epoch: Int,
+) -> StartResult(Message) {
+  State(
+    epoch: epoch,
+    last_time: 0,
+    machine_id: machine_id,
+    node_id: node_id,
+    idx: 0,
+  )
+  |> actor.start(handle_msg)
+}
+
+/// Generates an ULID using the given channel with a monotonicity check.
+/// This guarantees sortability if multiple ULID get created in the same millisecond.
+///
+/// ### Usage
+/// ```gleam
+/// import ids/ulid
+///
+/// let assert Ok(channel) = ulid.start()
+/// let Ok(id) = ulid.monotonic_generate(channel)
+/// ```
+pub fn generate(channel: Subject(Message)) -> Result(String, String) {
+  actor.call(channel, Generate, 1000)
+}
+
+/// Generates an ULID with the supplied timestamp and randomness.
+pub fn from_parts(
+  timestamp: Int,
+  randomness: BitString,
+) -> Result(String, String) {
+  case #(timestamp, randomness) {
+    #(time, <<rand:bit_string-size(80)>>) if time <= max_time ->
+      <<timestamp:size(48), rand:bit_string>>
+      |> encode_base32()
+      |> Ok
+    _other -> {
+      let error =
+        string.concat([
+          "Error: The timestamp is too large or randomness isn't 80 bits. Please use an Unix timestamp smaller than ",
+          int.to_string(max_time),
+          ".",
+        ])
+      Error(error)
+    }
+  }
+}
+
+/// Decodes an ULID into #(timestamp, randomness).
+pub fn decode(ulid: String) -> Result(#(Int, BitString), String) {
+  case decode_base32(ulid) {
+    Ok(<<timestamp:unsigned-size(48), randomness:bit_string-size(80)>>) ->
+      Ok(#(timestamp, randomness))
+    _other -> Error("Error: Decoding failed. Is a valid ULID being supplied?")
+  }
+}
+
+/// Actor message handler.
+fn handle_msg(msg: Message, state: State) -> Next(Message, State) {
+  case msg {
+    Generate(reply) -> {
+      erlang.system_time(erlang.Millisecond)
+      |> generate_response_ulid(reply, state)
+    }
+  }
+}
+
+/// Response message helper.
+fn generate_response_ulid(
+  timestamp: Int,
+  reply: Subject(Result(String, String)),
+  state: State,
+) -> Next(Message, State) {
+  case state.last_time == timestamp {
+    True -> {
+      let randomness =
+        state.last_random
+        |> decode_unsigned()
+        |> int.add(1)
+        |> encode_unsigned()
+
+      case from_parts(timestamp, randomness) {
+        Ok(ulid) -> actor.send(reply, Ok(ulid))
+        _error -> actor.send(reply, Error("Error: Couldn't generate ULID."))
+      }
+
+      actor.continue(State(last_time: timestamp, last_random: randomness))
+    }
+
+    False -> {
+      let randomness = crypto_strong_rand_bytes(10)
+
+      case from_parts(timestamp, randomness) {
+        Ok(ulid) -> actor.send(reply, Ok(ulid))
+        _error -> actor.send(reply, Error("Error: Couldn't generate ULID."))
+      }
+
+      actor.continue(State(last_time: timestamp, last_random: randomness))
+    }
+  }
+}
+
+/// Encode a bit_string using crockfords base32 encoding.
+fn encode_base32(bytes: BitString) -> String {
+  // calculate how many bits to pad to make the bit_string divisible by 5
+  let to_pad =
+    bytes
+    |> bit_size()
+    |> int.modulo(5)
+    |> result.unwrap(5)
+    |> int.subtract(5)
+    |> int.absolute_value()
+    |> int.modulo(5)
+    |> result.unwrap(0)
+
+  encode_bytes(<<0:size(to_pad), bytes:bit_string>>)
+}
+
+/// Recursively grabs 5 bits and uses them as index in the crockford alphabet and concatinates them to a string.
+fn encode_bytes(binary: BitString) -> String {
+  case binary {
+    <<index:unsigned-size(5), rest:bit_string>> -> {
+      crockford_alphabet
+      |> string.to_graphemes()
+      |> list.at(index)
+      |> result.unwrap("0")
+      |> string.append(encode_bytes(rest))
+    }
+    <<>> -> ""
+  }
+}
+
+/// Decode a string using crockford's base32 encoding.
+fn decode_base32(binary: String) -> Result(BitString, Nil) {
+  let crockford_with_index =
+    crockford_alphabet
+    |> string.to_graphemes()
+    |> list.index_map(fn(i, x) { #(x, i) })
+
+  let bits =
+    binary
+    |> string.to_graphemes()
+    |> list.fold(
+      <<>>,
+      fn(acc, c) {
+        let index =
+          crockford_with_index
+          |> list.key_find(c)
+          |> result.unwrap(0)
+
+        <<acc:bit_string, index:5>>
+      },
+    )
+
+  let padding =
+    bits
+    |> bit_size()
+    |> int.modulo(8)
+    |> result.unwrap(0)
+
+  case bits {
+    <<0:size(padding), res:bit_string>> -> Ok(res)
+    _other -> Error(Nil)
+  }
+}


### PR DESCRIPTION
This pull requests adds [Snowflake IDs](https://en.wikipedia.org/wiki/Snowflake_ID).

added functions:
- `snowflake.start(machine_id: Int)`
  - Starts a snowflake generator.
- `snowflake.start_with_epoch(machine_id: Int, epoch: Int)`
  - Starts a Snowflake generator with an epoch offset.
- `snowflake.generate(channel: Subject(Message))`
  - Generates a new id using a generator channel.
- `snowflake.decode(snowflake: Int)`
  - Decodes a Snowflake ID into #(timestamp, machine_id, idx).