### PR TITLE
Updates for Gleam 0.33 (+ partial exhaustiveness warning patches)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,10 @@
 name: test
-
 on:
   push:
     branches:
       - master
       - main
   pull_request:
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,7 +13,7 @@ jobs:
       - uses: erlef/setup-beam@v1.15.3
         with:
           otp-version: "25.2"
-          gleam-version: "0.32.2"
+          gleam-version: "0.33.0"
           rebar3-version: "3"
       - run: gleam format --check src test
       - run: gleam deps download

--- a/gleam.toml
+++ b/gleam.toml
@@ -3,12 +3,12 @@ version = "0.11.0"
 licences = ["Apache-2.0"]
 description = "✨ Unique IDs for Gleam"
 repository = { type = "github", user = "rvcas", repo = "ids" }
-gleam = ">= 0.32.2"
+gleam = ">= 0.33.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.32"
-gleam_otp = "~> 0.7"
-gleam_erlang = "~> 0.22"
+gleam_stdlib = "~> 0.34"
+gleam_otp = "~> 0.8"
+gleam_erlang = "~> 0.23"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.23.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "DA7A8E5540948DE10EB01B530869F8FF2FF6CAD8CFDA87626CE6EF63EBBF87CB" },
-  { name = "gleam_otp", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_erlang"], otp_app = "gleam_otp", source = "hex", outer_checksum = "ED7381E90636E18F5697FD7956EECCA635A3B65538DC2BE2D91A38E61DCE8903" },
-  { name = "gleam_stdlib", version = "0.32.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "07D64C26D014CF570F8ACADCE602761EA2E74C842D26F2FD49B0D61973D9966F" },
-  { name = "gleeunit", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D3682ED8C5F9CAE1C928F2506DE91625588CC752495988CBE0F5653A42A6F334" },
+  { name = "gleam_erlang", version = "0.23.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "C21CFB816C114784E669FFF4BBF433535EEA9960FA2F216209B8691E87156B96" },
+  { name = "gleam_otp", version = "0.8.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "18EF8242A5E54BA92F717C7222F03B3228AEE00D1F286D4C56C3E8C18AA2588E" },
+  { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
+  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
 ]
 
 [requirements]
-gleam_erlang = { version = "~> 0.22" }
-gleam_otp = { version = "~> 0.7" }
-gleam_stdlib = { version = "~> 0.32" }
+gleam_erlang = { version = "~> 0.23" }
+gleam_otp = { version = "~> 0.8" }
+gleam_stdlib = { version = "~> 0.34" }
 gleeunit = { version = "~> 1.0" }

--- a/src/ids/cuid.gleam
+++ b/src/ids/cuid.gleam
@@ -161,7 +161,8 @@ fn get_fingerprint() -> String {
 
   let hostid = { sum + list.length(localhost) + base } % operator
 
-  id + hostid
+  id
+  + hostid
   |> int.to_base36()
 }
 

--- a/src/ids/nanoid.gleam
+++ b/src/ids/nanoid.gleam
@@ -43,7 +43,7 @@ fn log(f: Float) -> Float
 ///
 pub fn generate() -> String {
   // TODO: When optional arguments with defaults becomes a thing in Gleam
-  //       make it possble to pass an 'alphabet' and 'size'. For now just
+  //       make it possible to pass an 'alphabet' and 'size'. For now just
   //       use hardcoded defaults...
   let alphabet: BitArray = default_alphabet
 
@@ -114,6 +114,9 @@ fn generate_nanoid(
       })
       |> bit_array.concat()
       |> Ok
+    Ok(False) ->
+      "Error: Invalid arguments."
+      |> Error
     Error(error) ->
       error
       |> Error
@@ -127,10 +130,16 @@ fn check_nanoid_args(size: Int, alphabet: BitArray) -> Result(Bool, String) {
         Ok(True) ->
           True
           |> Ok
+        Ok(False) ->
+          False
+          |> Ok
         Error(error) ->
           error
           |> Error
       }
+    Ok(False) ->
+      False
+      |> Ok
     Error(error) ->
       error
       |> Error
@@ -172,7 +181,7 @@ fn random_bytes(size: Int) -> List(Int) {
   |> bin_to_list()
 }
 
-// Calculate a bitmask value that can be used to transform byte vaules 
+// Calculate a bitmask value that can be used to transform byte values 
 // into values that are closer to the size of the alphabet used. The 
 // bitmask value will be the closest `2^31 - 1` number, that exceeds 
 // the alphabet size. For example, the bitmask of the alphabet of size 
@@ -190,9 +199,8 @@ fn calculate_mask(alphabet_length: Int) -> Int {
 fn calculate_step(mask: Int, size: Int, alphabet_length: Int) -> Int {
   let step: Float =
     float.ceiling(
-      1.6 *. int.to_float(mask) *. int.to_float(size) /. int.to_float(
-        alphabet_length,
-      ),
+      1.6 *. int.to_float(mask) *. int.to_float(size)
+      /. int.to_float(alphabet_length),
     )
   float.round(step)
 }

--- a/src/ids/ulid.gleam
+++ b/src/ids/ulid.gleam
@@ -142,7 +142,7 @@ fn encode_base32(bytes: BitArray) -> String {
   encode_bytes(<<0:size(to_pad), bytes:bits>>)
 }
 
-/// Recursively grabs 5 bits and uses them as index in the crockford alphabet and concatinates them to a string.
+/// Recursively grabs 5 bits and uses them as index in the crockford alphabet and concatenates them to a string.
 fn encode_bytes(binary: BitArray) -> String {
   case binary {
     <<index:unsigned-size(5), rest:bits>> -> {
@@ -161,22 +161,19 @@ fn decode_base32(binary: String) -> Result(BitArray, Nil) {
   let crockford_with_index =
     crockford_alphabet
     |> string.to_graphemes()
-    |> list.index_map(fn(i, x) { #(x, i) })
+    |> list.index_map(fn(i, x) { #(i, x) })
 
   let bits =
     binary
     |> string.to_graphemes()
-    |> list.fold(
-      <<>>,
-      fn(acc, c) {
-        let index =
-          crockford_with_index
-          |> list.key_find(c)
-          |> result.unwrap(0)
+    |> list.fold(<<>>, fn(acc, c) {
+      let index =
+        crockford_with_index
+        |> list.key_find(c)
+        |> result.unwrap(0)
 
-        <<acc:bits, index:5>>
-      },
-    )
+      <<acc:bits, index:5>>
+    })
 
   let padding =
     bits

--- a/src/ids/ulid.gleam
+++ b/src/ids/ulid.gleam
@@ -152,7 +152,7 @@ fn encode_bytes(binary: BitArray) -> String {
       |> result.unwrap("0")
       |> string.append(encode_bytes(rest))
     }
-    <<>> -> ""
+    <<>> | _ -> ""
   }
 }
 

--- a/src/ids/uuid.gleam
+++ b/src/ids/uuid.gleam
@@ -254,6 +254,7 @@ fn e(n: Int) -> Int {
     13 -> 100
     14 -> 101
     15 -> 102
+    _ -> panic as "Error: unexpected value in `e`"
   }
 }
 
@@ -275,5 +276,6 @@ fn d(n: Int) -> Int {
     100 -> 13
     101 -> 14
     102 -> 15
+    _ -> panic as "Error: unexpected value in `d`"
   }
 }

--- a/test/ids/cuid_test.gleam
+++ b/test/ids/cuid_test.gleam
@@ -1,7 +1,7 @@
 import gleeunit/should
 import ids/cuid
 import gleam/iterator.{Done, Next}
-import gleam/map
+import gleam/dict
 import gleam/pair
 import gleam/string
 
@@ -61,20 +61,17 @@ fn check_collision(func: fn() -> String) -> Bool {
       True -> Next(element: func(), accumulator: acc + 1)
     }
   })
-  |> iterator.fold(
-    from: #(map.new(), True),
-    with: fn(acc, id) {
-      let #(id_map, flag) = acc
+  |> iterator.fold(from: #(dict.new(), True), with: fn(acc, id) {
+    let #(id_map, flag) = acc
 
-      case flag {
-        False -> acc
-        True ->
-          case map.get(id_map, id) {
-            Ok(_) -> #(id_map, False)
-            Error(_) -> #(map.insert(id_map, id, id), True)
-          }
-      }
-    },
-  )
+    case flag {
+      False -> acc
+      True ->
+        case dict.get(id_map, id) {
+          Ok(_) -> #(id_map, False)
+          Error(_) -> #(dict.insert(id_map, id, id), True)
+        }
+    }
+  })
   |> pair.second()
 }

--- a/test/ids/ulid_test.gleam
+++ b/test/ids/ulid_test.gleam
@@ -30,18 +30,16 @@ pub fn from_timestamp_test() {
 
 pub fn from_parts_test() {
   let assert Ok(id_1) =
-    ulid.from_parts(
-      1_696_346_659_217,
-      <<150, 184, 121, 192, 42, 76, 148, 57, 61, 61>>,
-    )
+    ulid.from_parts(1_696_346_659_217, <<
+      150, 184, 121, 192, 42, 76, 148, 57, 61, 61,
+    >>)
   id_1
   |> should.equal("01HBV27PCHJTW7KG1A9JA3JF9X")
 
   let assert Ok(id_2) =
-    ulid.from_parts(
-      281_474_976_710_655,
-      <<255, 255, 255, 255, 255, 255, 255, 255, 255, 255>>,
-    )
+    ulid.from_parts(281_474_976_710_655, <<
+      255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    >>)
   id_2
   |> should.equal("7ZZZZZZZZZZZZZZZZZZZZZZZZZ")
 }


### PR DESCRIPTION
I have fixed some pattern exhaustiveness warnings, but I had to use panic with the assumption that the code was never meant to reach there anyway; so, just to satisfy the compiler. However, I am unable to fix it for some because they won't accept `assert` or `case` and I am unsure how you would prefer to proceed.