### PR TITLE
Add TypeID

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.1
-      - uses: erlef/setup-beam@v1.15.3
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
         with:
-          otp-version: "27"
+          otp-version: "26"
           gleam-version: "1.2.0"
           rebar3-version: "3"
       - run: gleam format --check src test
-      - run: gleam deps download
       - run: gleam test

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [NanoID](https://github.com/ai/nanoid)
 - [ULID](https://github.com/ulid/spec)
 - [Snowflake ID](https://en.wikipedia.org/wiki/Snowflake_ID)
+- [TypeID](https://github.com/jetify-com/typeid)
 
 ## Installation
 
@@ -30,3 +31,6 @@ gleam add ids
 3. [Ecto UUID](https://github.com/elixir-ecto/ecto/blob/v3.5.4/lib/ecto/uuid.ex)
 4. [Elixir UUID](https://github.com/bitwalker/uniq)
 5. [Rust Snowflake ID](https://github.com/BinChengZhao/snowflake-rs)
+6. [TypeID Spec](https://github.com/jetify-com/typeid/tree/main/spec)
+6. [Elixir TypeID](https://github.com/sloanelybutsurely/typeid-elixir)
+

--- a/src/ids/base32.gleam
+++ b/src/ids/base32.gleam
@@ -1,4 +1,4 @@
-//// Module for shared functionality.
+//// Module for Base32 encoding.
 
 import gleam/list
 import gleam/result
@@ -7,7 +7,7 @@ import gleam/string
 /// Encode a 128 bit BitArray with base32 encoding using the supplied alphabet.
 /// Used by ULID and TypeID
 @internal
-pub fn encode_base32(bytes: BitArray, alphabet: String) -> String {
+pub fn encode(bytes: BitArray, alphabet: String) -> String {
   // pad 2 bits because we only supply 128 bits of data but need 130 bits for encoding
   encode_bytes(<<0:size(2), bytes:bits>>, alphabet)
 }
@@ -29,7 +29,7 @@ fn encode_bytes(binary: BitArray, alphabet: String) -> String {
 /// Decode a string with the supplied alphabet and base32 encoding.
 /// Used by ULID and TypeID
 @internal
-pub fn decode_base32(binary: String, alphabet: String) -> Result(BitArray, Nil) {
+pub fn decode(binary: String, alphabet: String) -> Result(BitArray, Nil) {
   let alphabet_with_index =
     alphabet
     |> string.to_graphemes

--- a/src/ids/base32.gleam
+++ b/src/ids/base32.gleam
@@ -8,17 +8,21 @@ import gleam/string
 /// Used by ULID and TypeID
 @internal
 pub fn encode(bytes: BitArray, alphabet: String) -> String {
+  let alphabet_with_index =
+    alphabet
+    |> string.to_graphemes
+    |> list.index_map(fn(x, i) { #(i, x) })
+
   // pad 2 bits because we only supply 128 bits of data but need 130 bits for encoding
-  encode_bytes(<<0:size(2), bytes:bits>>, alphabet)
+  encode_bytes(<<0:size(2), bytes:bits>>, alphabet_with_index)
 }
 
 /// Recursively grabs 5 bits and uses them as index in the alphabet and concatinates them to a string.
-fn encode_bytes(binary: BitArray, alphabet: String) -> String {
+fn encode_bytes(binary: BitArray, alphabet: List(#(Int, String))) -> String {
   case binary {
     <<index:unsigned-size(5), rest:bits>> -> {
       alphabet
-      |> string.to_graphemes
-      |> list.at(index)
+      |> list.key_find(index)
       |> result.unwrap("0")
       |> string.append(encode_bytes(rest, alphabet))
     }

--- a/src/ids/cuid.gleam
+++ b/src/ids/cuid.gleam
@@ -6,11 +6,11 @@
 //// Slugs are also supported.
 ////
 
+import gleam/erlang.{Millisecond}
+import gleam/erlang/process.{type Subject}
 import gleam/int
 import gleam/list
-import gleam/erlang.{Millisecond}
 import gleam/otp/actor.{type Next, type StartResult}
-import gleam/erlang/process.{type Subject}
 import gleam/string
 
 /// The messages handled by the actor.
@@ -88,15 +88,15 @@ fn handle_msg(msg: Message, state: State) -> Next(Message, State) {
       let slug =
         format_id([
           timestamp()
-          |> string.slice(-2, 2),
+            |> string.slice(-2, 2),
           format_count(state.count)
-          |> string.slice(-4, 4),
+            |> string.slice(-4, 4),
           string.concat([
             string.slice(state.fingerprint, 0, 1),
             string.slice(state.fingerprint, -1, 1),
           ]),
           random_block()
-          |> string.slice(-2, 2),
+            |> string.slice(-2, 2),
         ])
       actor.send(reply, slug)
       actor.continue(State(..state, count: new_count(state.count)))
@@ -161,8 +161,7 @@ fn get_fingerprint() -> String {
 
   let hostid = { sum + list.length(localhost) + base } % operator
 
-  id
-  + hostid
+  id + hostid
   |> int.to_base36()
 }
 

--- a/src/ids/nanoid.gleam
+++ b/src/ids/nanoid.gleam
@@ -2,11 +2,11 @@
 //// and unique string IDs.
 ////
 
-import gleam/string
 import gleam/bit_array
 import gleam/float
 import gleam/int
 import gleam/list
+import gleam/string
 
 /// The default alphabet used when generating NanoIDs.
 pub const default_alphabet: BitArray = <<
@@ -172,7 +172,9 @@ fn calculate_mask(alphabet_length: Int) -> Int {
 fn calculate_step(mask: Int, size: Int, alphabet_length: Int) -> Int {
   let step: Float =
     float.ceiling(
-      1.6 *. int.to_float(mask) *. int.to_float(size)
+      1.6
+      *. int.to_float(mask)
+      *. int.to_float(size)
       /. int.to_float(alphabet_length),
     )
   float.round(step)

--- a/src/ids/snowflake.gleam
+++ b/src/ids/snowflake.gleam
@@ -1,11 +1,11 @@
 //// A module for generating Snowflake IDs.
 
-import gleam/int
-import gleam/string
-import gleam/result
 import gleam/erlang
-import gleam/otp/actor.{type Next}
 import gleam/erlang/process.{type Subject}
+import gleam/int
+import gleam/otp/actor.{type Next}
+import gleam/result
+import gleam/string
 
 @external(erlang, "binary", "encode_unsigned")
 fn encode_unsigned(i: Int) -> BitArray

--- a/src/ids/typeid.gleam
+++ b/src/ids/typeid.gleam
@@ -4,7 +4,7 @@ import gleam/bit_array
 import gleam/regex
 import gleam/result
 import gleam/string
-import ids/utils
+import ids/base32
 import ids/uuid
 
 @internal
@@ -47,7 +47,7 @@ pub fn from_uuid(
         |> uuid.dump,
       )
 
-      let id = utils.encode_base32(raw_uuid, alphabet)
+      let id = base32.encode(raw_uuid, alphabet)
 
       Ok(p <> id)
     }
@@ -84,7 +84,7 @@ pub fn decode(tid) -> Result(#(String, String), String) {
 fn decode_suffix(suffix) -> Result(String, String) {
   use raw_uuid <- result.try(
     suffix
-    |> utils.decode_base32(alphabet)
+    |> base32.decode(alphabet)
     |> result.replace_error("Error: Couldn't decode suffix."),
   )
 

--- a/src/ids/typeid.gleam
+++ b/src/ids/typeid.gleam
@@ -1,0 +1,98 @@
+//// Module for generating TypeIDs.
+
+import gleam/bit_array
+import gleam/regex
+import gleam/result
+import gleam/string
+import ids/utils
+import ids/uuid
+
+@internal
+pub const alphabet = "0123456789abcdefghjkmnpqrstvwxyz"
+
+/// Generate a TypeID using the supplied prefix. Prefix may be an empty string.
+///
+/// ### Usage
+/// ```gleam
+/// generate("user") // Ok("user_01hz7jxhgpfxh9m33bn41tcg9t")
+/// generate("") // Ok("01hz7jv26zfnx9gpb0hvyc4pss")
+/// ```
+pub fn generate(prefix prefix: String) -> Result(String, String) {
+  use uuid <- result.try(uuid.generate_v7())
+  from_uuid(prefix: prefix, uuid: uuid)
+}
+
+/// Generate a TypeID using the supplied prefix and UUID. Prefix may be an empty string.
+///
+/// ### Usage
+/// ```gleam
+/// from_uuid("user", "018fcec0-b44b-7ce2-b187-2f08349beab9") // Ok("user_01hz7c1d2bfkhb31sf10t9qtns")
+/// ```
+pub fn from_uuid(
+  prefix prefix: String,
+  uuid uuid: String,
+) -> Result(String, String) {
+  let assert Ok(re) = regex.from_string("^([a-z]([a-z_]{0,61}[a-z])?)?$")
+
+  case regex.check(re, prefix) {
+    True -> {
+      let p = case prefix {
+        "" -> ""
+        _ -> prefix <> "_"
+      }
+
+      use raw_uuid <- result.try(
+        uuid
+        |> bit_array.from_string
+        |> uuid.dump,
+      )
+
+      let id = utils.encode_base32(raw_uuid, alphabet)
+
+      Ok(p <> id)
+    }
+    False ->
+      Error(
+        "Error: Prefix must contain at most 63 characters and only lowercase alphabetic ASCII characters [a-z], or an underscore.",
+      )
+  }
+}
+
+/// Decode a TypeID into a tuple of #(prefix, uuid)
+///
+/// ### Usage
+/// ```gleam
+/// decode("user_01hz7c1d2bfkhb31sf10t9qtns") // Ok(#("user", "018fcec0-b44b-7ce2-b187-2f08349beab9"))
+/// ```
+pub fn decode(tid) -> Result(#(String, String), String) {
+  case tid |> string.reverse |> string.split_once(on: "_") {
+    Ok(#(xiffus, xiferp)) -> {
+      use uuid <- result.try(
+        xiffus
+        |> string.reverse
+        |> decode_suffix,
+      )
+      Ok(#(string.reverse(xiferp), uuid))
+    }
+    Error(Nil) -> {
+      use uuid <- result.try(decode_suffix(tid))
+      Ok(#("", uuid))
+    }
+  }
+}
+
+fn decode_suffix(suffix) -> Result(String, String) {
+  use raw_uuid <- result.try(
+    suffix
+    |> utils.decode_base32(alphabet)
+    |> result.replace_error("Error: Couldn't decode suffix."),
+  )
+
+  use uuid <- result.try(
+    raw_uuid
+    |> uuid.cast
+    |> result.replace_error("Error: Couldn't decode UUID."),
+  )
+
+  Ok(uuid)
+}

--- a/src/ids/ulid.gleam
+++ b/src/ids/ulid.gleam
@@ -5,7 +5,7 @@ import gleam/erlang/process.{type Subject}
 import gleam/int
 import gleam/otp/actor.{type Next, type StartResult}
 import gleam/string
-import ids/utils
+import ids/base32
 
 @internal
 pub const crockford_alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
@@ -101,7 +101,7 @@ pub fn from_parts(
   case timestamp, randomness {
     time, <<rand:bits-size(80)>> if time <= max_time ->
       <<timestamp:size(48), rand:bits>>
-      |> utils.encode_base32(crockford_alphabet)
+      |> base32.encode(crockford_alphabet)
       |> Ok
     _, _ -> {
       let error =
@@ -117,7 +117,7 @@ pub fn from_parts(
 
 /// Decodes an ULID into #(timestamp, randomness).
 pub fn decode(ulid: String) -> Result(#(Int, BitArray), String) {
-  case utils.decode_base32(ulid, crockford_alphabet) {
+  case base32.decode(ulid, crockford_alphabet) {
     Ok(<<timestamp:unsigned-size(48), randomness:bits-size(80)>>) ->
       Ok(#(timestamp, randomness))
     _other -> Error("Error: Decoding failed. Is a valid ULID being supplied?")

--- a/src/ids/utils.gleam
+++ b/src/ids/utils.gleam
@@ -1,0 +1,54 @@
+//// Module for shared functionality.
+
+import gleam/list
+import gleam/result
+import gleam/string
+
+/// Encode a 128 bit BitArray with base32 encoding using the supplied alphabet.
+/// Used by ULID and TypeID
+@internal
+pub fn encode_base32(bytes: BitArray, alphabet: String) -> String {
+  // pad 2 bits because we only supply 128 bits of data but need 130 bits for encoding
+  encode_bytes(<<0:size(2), bytes:bits>>, alphabet)
+}
+
+/// Recursively grabs 5 bits and uses them as index in the alphabet and concatinates them to a string.
+fn encode_bytes(binary: BitArray, alphabet: String) -> String {
+  case binary {
+    <<index:unsigned-size(5), rest:bits>> -> {
+      alphabet
+      |> string.to_graphemes
+      |> list.at(index)
+      |> result.unwrap("0")
+      |> string.append(encode_bytes(rest, alphabet))
+    }
+    _ -> ""
+  }
+}
+
+/// Decode a string with the supplied alphabet and base32 encoding.
+/// Used by ULID and TypeID
+@internal
+pub fn decode_base32(binary: String, alphabet: String) -> Result(BitArray, Nil) {
+  let alphabet_with_index =
+    alphabet
+    |> string.to_graphemes
+    |> list.index_map(fn(x, i) { #(x, i) })
+
+  let bits =
+    binary
+    |> string.to_graphemes
+    |> list.fold(<<>>, fn(acc, c) {
+      let index =
+        alphabet_with_index
+        |> list.key_find(c)
+        |> result.unwrap(0)
+
+      <<acc:bits, index:5>>
+    })
+
+  case bits {
+    <<0:size(2), res:bits>> -> Ok(res)
+    _other -> Error(Nil)
+  }
+}

--- a/src/ids/uuid.gleam
+++ b/src/ids/uuid.gleam
@@ -5,8 +5,8 @@
 ////
 
 import gleam/bit_array
-import gleam/result
 import gleam/erlang
+import gleam/result
 
 @external(erlang, "crypto", "strong_rand_bytes")
 fn crypto_strong_rand_bytes(n: Int) -> BitArray
@@ -74,7 +74,8 @@ pub fn decode_v7(
   })
 }
 
-fn cast(raw_uuid: BitArray) -> Result(String, String) {
+@internal
+pub fn cast(raw_uuid: BitArray) -> Result(String, String) {
   case raw_uuid {
     <<
       a1:size(4),
@@ -157,7 +158,8 @@ fn cast(raw_uuid: BitArray) -> Result(String, String) {
   }
 }
 
-fn dump(uuid: BitArray) -> Result(BitArray, String) {
+@internal
+pub fn dump(uuid: BitArray) -> Result(BitArray, String) {
   case uuid {
     <<
       a1,

--- a/test/ids/cuid_test.gleam
+++ b/test/ids/cuid_test.gleam
@@ -1,9 +1,9 @@
-import gleeunit/should
-import ids/cuid
-import gleam/iterator.{Done, Next}
 import gleam/dict
+import gleam/iterator.{Done, Next}
 import gleam/pair
 import gleam/string
+import gleeunit/should
+import ids/cuid
 
 pub fn gen_test() {
   let assert Ok(channel) = cuid.start()

--- a/test/ids/nanoid_test.gleam
+++ b/test/ids/nanoid_test.gleam
@@ -1,10 +1,10 @@
-import gleeunit
-import ids/nanoid
-import gleeunit/should
-import gleam/list
-import gleam/string
 import gleam/bit_array
+import gleam/list
 import gleam/set.{type Set}
+import gleam/string
+import gleeunit
+import gleeunit/should
+import ids/nanoid
 
 pub fn main() {
   gleeunit.main()

--- a/test/ids/snowflake_test.gleam
+++ b/test/ids/snowflake_test.gleam
@@ -1,9 +1,9 @@
-import ids/snowflake
-import gleeunit/should
-import gleam/string
+import gleam/erlang
 import gleam/int
 import gleam/list
-import gleam/erlang
+import gleam/string
+import gleeunit/should
+import ids/snowflake
 
 pub fn gen_test() {
   let machine_id = 1

--- a/test/ids/typeid_test.gleam
+++ b/test/ids/typeid_test.gleam
@@ -1,0 +1,99 @@
+import gleam/bit_array
+import gleam/string
+import gleeunit/should
+import ids/typeid
+
+pub fn gen_test() {
+  typeid.generate("test")
+  |> should.be_ok
+
+  typeid.generate("te_st")
+  |> should.be_ok
+
+  typeid.generate("123")
+  |> should.be_error
+
+  let assert Ok(id) = typeid.generate("test")
+
+  id
+  |> string.starts_with("test_")
+  |> should.be_true
+
+  id
+  |> string.length
+  |> should.equal(31)
+}
+
+pub fn gen_empty_prefix_test() {
+  let assert Ok(id) = typeid.generate("")
+
+  id
+  |> string.contains("_")
+  |> should.be_false
+
+  id
+  |> string.length
+  |> should.equal(26)
+}
+
+pub fn from_uuid_test() {
+  typeid.from_uuid("test", "wobble")
+  |> should.be_error
+
+  typeid.from_uuid("test", "018fcec0-b44b-7ce2-b187-2f08349beab9")
+  |> should.be_ok
+
+  let assert Ok(id) =
+    typeid.from_uuid("test", "018fcec0-b44b-7ce2-b187-2f08349beab9")
+
+  id
+  |> should.equal("test_01hz7c1d2bfkhb31sf10t9qtns")
+}
+
+pub fn decode_test() {
+  let assert Ok(id1) = typeid.generate("test")
+  let assert Ok(id2) = typeid.generate("")
+  let assert Ok(id3) =
+    typeid.from_uuid("test", "018fcec0-b44b-7ce2-b187-2f08349beab9")
+
+  id1
+  |> typeid.decode
+  |> should.be_ok
+
+  id2
+  |> typeid.decode
+  |> should.be_ok
+
+  ""
+  |> typeid.decode
+  |> should.be_error
+
+  "lkjgijkldsa"
+  |> typeid.decode
+  |> should.be_error
+
+  let assert Ok(#(prefix1, suffix1)) = typeid.decode(id1)
+  let assert Ok(#(prefix2, _suffix2)) = typeid.decode(id2)
+  let assert Ok(#(_prefix3, suffix3)) = typeid.decode(id3)
+
+  prefix1
+  |> should.equal("test")
+
+  prefix2
+  |> should.equal("")
+
+  let assert <<
+    _:size(64),
+    45,
+    _:size(32),
+    45,
+    _:size(32),
+    45,
+    _:size(32),
+    45,
+    _:size(96),
+  >> = bit_array.from_string(suffix1)
+
+  suffix3
+  |> should.equal("018fcec0-b44b-7ce2-b187-2f08349beab9")
+}

--- a/test/ids/ulid_test.gleam
+++ b/test/ids/ulid_test.gleam
@@ -1,8 +1,8 @@
-import ids/ulid
-import gleeunit/should
-import gleam/string
 import gleam/list
 import gleam/result
+import gleam/string
+import gleeunit/should
+import ids/ulid
 
 @external(erlang, "binary", "decode_unsigned")
 fn decode_unsigned(b: BitArray) -> Int

--- a/test/ids/uuid_test.gleam
+++ b/test/ids/uuid_test.gleam
@@ -1,7 +1,7 @@
-import gleeunit/should
-import ids/uuid
 import gleam/bit_array
 import gleam/erlang
+import gleeunit/should
+import ids/uuid
 
 pub fn gen_v4_test() {
   let assert Ok(id) = uuid.generate_v4()


### PR DESCRIPTION
This PR adds support for [TypeID](https://github.com/jetify-com/typeid/tree/main/spec).
For this I had to move the base32 encoding from ULID to it's own module as it's being reused in TypeIDs.