### PR TITLE
Update to work with latest stdlib

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -3,12 +3,14 @@ version = "0.13.0"
 licences = ["Apache-2.0"]
 description = "✨ Unique IDs for Gleam"
 repository = { type = "github", user = "rvcas", repo = "ids" }
-gleam = ">= 0.32.2"
+gleam = ">= 1.1.0"
 
 [dependencies]
-gleam_stdlib = ">= 0.34.0 and < 2.0.0"
+gleam_stdlib = ">= 0.50.0 and < 2.0.0"
 gleam_otp = "~> 0.10"
 gleam_erlang = "~> 0.25"
+gleam_yielder = ">= 1.1.0 and < 2.0.0"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,18 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
-  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
+  { name = "gleam_otp", version = "0.16.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "FA0EB761339749B4E82D63016C6A18C4E6662DA05BAB6F1346F9AF2E679E301A" },
+  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
+  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
+  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
 ]
 
 [requirements]
 gleam_erlang = { version = "~> 0.25" }
 gleam_otp = { version = "~> 0.10" }
-gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
+gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.50.0 and < 2.0.0" }
+gleam_yielder = { version = ">= 1.1.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/src/ids/cuid.gleam
+++ b/src/ids/cuid.gleam
@@ -131,7 +131,7 @@ fn timestamp() -> String {
 fn format_count(num: Int) -> String {
   num
   |> int.to_base36()
-  |> string.pad_left(to: block_size, with: "0")
+  |> string.pad_start(to: block_size, with: "0")
 }
 
 type CharList
@@ -171,5 +171,5 @@ fn rand_uniform(n: Int) -> Int
 fn random_block() -> String {
   rand_uniform(discrete_values - 1)
   |> int.to_base36()
-  |> string.pad_left(to: block_size, with: "0")
+  |> string.pad_start(to: block_size, with: "0")
 }

--- a/src/ids/typeid.gleam
+++ b/src/ids/typeid.gleam
@@ -1,7 +1,7 @@
 //// Module for generating TypeIDs.
 
 import gleam/bit_array
-import gleam/regex
+import gleam/regexp
 import gleam/result
 import gleam/string
 import ids/base32
@@ -32,9 +32,9 @@ pub fn from_uuid(
   prefix prefix: String,
   uuid uuid: String,
 ) -> Result(String, String) {
-  let assert Ok(re) = regex.from_string("^([a-z]([a-z_]{0,61}[a-z])?)?$")
+  let assert Ok(re) = regexp.from_string("^([a-z]([a-z_]{0,61}[a-z])?)?$")
 
-  case regex.check(re, prefix) {
+  case regexp.check(re, prefix) {
     True -> {
       let p = case prefix {
         "" -> ""

--- a/test/ids/cuid_test.gleam
+++ b/test/ids/cuid_test.gleam
@@ -1,7 +1,7 @@
 import gleam/dict
-import gleam/iterator.{Done, Next}
 import gleam/pair
 import gleam/string
+import gleam/yielder.{Done, Next}
 import gleeunit/should
 import ids/cuid
 
@@ -55,13 +55,13 @@ const max: Int = 100_000
 
 fn check_collision(func: fn() -> String) -> Bool {
   start
-  |> iterator.unfold(with: fn(acc) {
+  |> yielder.unfold(with: fn(acc) {
     case acc < max {
       False -> Done
       True -> Next(element: func(), accumulator: acc + 1)
     }
   })
-  |> iterator.fold(from: #(dict.new(), True), with: fn(acc, id) {
+  |> yielder.fold(from: #(dict.new(), True), with: fn(acc, id) {
     let #(id_dict, flag) = acc
 
     case flag {


### PR DESCRIPTION
Hello,

This fixes some breaking changes introduced by Gleam's stdlib in later versions (deprecated packages replaced by external ones, and renamed functions in the string package). The gleam version constraint is to remove a warning due to the use of the `@internal` annotation:

```
warning: Incompatible gleam version range
   ┌─ .../ids/src/ids/typeid.gleam:10:1
   │
10 │ @internal
   │ ^^^^^^^^^ This requires a Gleam version >= 1.1.0

The `@internal` annotation was introduced in version v1.1.0. But the Gleam
version range specified in your `gleam.toml` would allow this code to run
on an earlier version like v0.32.2, resulting in compilation errors!
Hint: Remove the version constraint from your `gleam.toml` or update it to be:

    gleam = ">= 1.1.0"
```

Thanks!
Martin